### PR TITLE
Cross-platform build of project

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "author": "Kirill Maltsev <maltsevkirill@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "compile": "rm -f lib/*.js && rm -f lib/modules/*.js && node_modules/.bin/babel -d lib/ lib/",
-    "lint": "node_modules/.bin/eslint *.js lib/*.es6 lib/modules/*.es6 test/",
+    "compile": "rimraf lib/*.js && rimraf lib/modules/*.js && babel -d lib/ lib/",
+    "lint": "eslint *.js lib/*.es6 lib/modules/*.es6 test/",
     "pretest": "npm run lint && npm run compile",
-    "test": "node_modules/.bin/_mocha --compilers js:babel-core/register --recursive --check-leaks",
+    "test": "mocha --compilers js:babel-core/register --recursive --check-leaks",
     "prepublish": "npm run compile"
   },
   "keywords": [
@@ -33,11 +33,12 @@
   "devDependencies": {
     "babel-cli": "^6.1.18",
     "babel-core": "^6.1.21",
-    "babel-eslint": "^4.1.5",
+    "babel-eslint": "^6.0.2",
     "babel-preset-es2015": "^6.1.18",
     "eslint": "^2.1.0",
     "expect": "^1.13.0",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "rimraf": "^2.5.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Windows machines are not able to work with `rm` command and do not work correctly with the `./node_modules` in npm scripts.