### PR TITLE
Remove redundant attribute type="submit" from <button>

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Minified:
 Removes redundant attributes from tags if they contain default values:
 - `method="get"` from `<form>`
 - `type="text"` from `<input>`
+- `type="submit"` from `<button>`
 - `language="javascript"` and `type="text/javascript"` from `<script>`
 - `charset` from `<script>` if it's an external script
 - `media="all"` from `<style>` and `<link>`

--- a/lib/modules/removeRedundantAttributes.es6
+++ b/lib/modules/removeRedundantAttributes.es6
@@ -7,6 +7,10 @@ const redundantAttributes = {
         'type': 'text'
     },
 
+    'button': {
+        'type': 'submit'
+    },
+
     'script': {
         'language': 'javascript',
         'type': 'text/javascript',

--- a/test/modules/removeRedundantAttributes.js
+++ b/test/modules/removeRedundantAttributes.js
@@ -19,6 +19,14 @@ describe('removeRedundantAttributes', () => {
         );
     });
 
+    it('should remove type="submit" from <button>', () => {
+        return init(
+            '<button type="submit">Button</button>',
+            '<button>Button</button>',
+            options
+        );
+    });
+
     it('should remove language="javascript" and type="text/javascript" from <script>', () => {
         return init(
             '<script language="javascript" type="text/javascript"></script>',


### PR DESCRIPTION
Source: https://developer.mozilla.org/ru/docs/Web/HTML/Element/button

> The type of the button. Possible values are:
>   * **submit**: The button submits the form data to the server. **This is the default if the attribute** is not specified, or if the attribute is dynamically changed to an empty or invalid value.