### PR TITLE
Fix options loading and merging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,9 +35,7 @@ export function loadConfig(
                 delete (rc.config as HtmlnanoOptionsConfigFile).preset;
             }
 
-            if (!options) {
-                restConfig = rc.config as Partial<HtmlnanoOptions>;
-            }
+            restConfig = { ...(rc.config as Partial<HtmlnanoOptions>), ...restConfig };
         }
     }
 


### PR DESCRIPTION
I believe the old code didn't handle the edge case when both `options` and `rc.config` were present. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration handling: settings from configuration files are now consistently merged with runtime options. Runtime options continue to take precedence on conflicts, but file-based settings are no longer ignored when options are provided. This ensures more predictable behavior across environments and prevents unexpected defaults from overriding user-provided configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->