### PR TITLE
Add CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,10 @@ htmlnano
     });
 ```
 
+Also, you can use it as CLI tool:
+
+```bash
+node_modules/.bin/htmlnano --help
+```
+
 More usage examples (PostHTML, Gulp, Webpack): https://htmlnano.netlify.app/next/usage

--- a/docs/docs/020-usage.md
+++ b/docs/docs/020-usage.md
@@ -61,8 +61,17 @@ posthtml(posthtmlPlugins)
 
 ## CLI
 
+You can use `htmlnano` as a CLI tool:
+
 ```bash
 node_modules/.bin/htmlnano --help
+```
+
+The options can be passed via the configuration file:
+
+```bash
+echo '{"collapseWhitespace": "all", "removeComments": "all"}' > config.json
+node_modules/.bin/htmlnano test.html -c config.json
 ```
 
 

--- a/docs/docs/020-usage.md
+++ b/docs/docs/020-usage.md
@@ -59,6 +59,12 @@ posthtml(posthtmlPlugins)
     });
 ```
 
+## CLI
+
+```bash
+node_modules/.bin/htmlnano --help
+```
+
 
 ## Webpack
 

--- a/docs/docs/030-config.md
+++ b/docs/docs/030-config.md
@@ -19,3 +19,13 @@ If you want to specify a preset that way, use `preset` key:
 
 Configuration files have lower precedence than passing options to `htmlnano` directly.
 So if you use both ways, then the configuration file would be ignored.
+
+### Custom path
+
+You can also pass a configuration file path in `options`:
+
+```js
+htmlnano.process(html, {
+    configPath: 'config.json',
+})
+```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && bunchee",
+    "postbuild": "chmod +x dist/bin.js",
     "compile": "npm run build",
     "lint": "eslint --fix .",
     "pretest": "npm run lint && npm run compile",
@@ -19,6 +20,7 @@
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
+  "bin": "./dist/bin.js",
   "exports": {
     "./helpers": {
       "types": "./dist/helpers.d.ts",
@@ -55,6 +57,7 @@
   ],
   "dependencies": {
     "@types/relateurl": "^0.2.33",
+    "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",
     "posthtml": "^0.16.5"
   },

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { program } from 'commander';
+import fs from 'fs';
+import process from 'process';
+import { process as processHtml, presets } from '../index.js';
+import type { HtmlnanoPreset, HtmlnanoOptions } from '../types.js';
+
+program
+    .name('htmlnano')
+    .description('Minify HTML with htmlnano')
+    .argument('[input]', 'input file', '-')
+    .option('-o, --output <file>', 'output file', '-')
+    .option('-p, --preset <preset>', 'preset to use', 'safe')
+    .option('-c, --config <file>', 'path to config file')
+    .action(async (input: string | undefined, options: { output?: string; preset?: string; config?: string }) => {
+        const { preset, output } = options;
+
+        if (!preset || !(preset in presets)) {
+            const available = Object.keys(presets).join(', ');
+            process.stderr.write(`Unknown preset: ${preset}. Available presets: ${available}\n`);
+            process.exitCode = 1;
+            return;
+        }
+
+        const html = fs.readFileSync(input && input !== '-' ? input : 0, 'utf8');
+
+        const key = preset as keyof typeof presets;
+        const chosenPreset: HtmlnanoPreset = presets[key];
+
+        const htmlnanoOptions: HtmlnanoOptions = {};
+        if (options.config) {
+            htmlnanoOptions.configPath = options.config;
+        }
+
+        const result = await processHtml(html, htmlnanoOptions, chosenPreset);
+
+        if (output && output !== '-') {
+            fs.writeFileSync(output, result.html);
+        } else {
+            process.stdout.write(result.html);
+        }
+    });
+
+program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import type PostHTML from 'posthtml';
 
 export type * from './types';
 
-const presets: HtmlnanoPredefinedPresets = {
+export const presets: HtmlnanoPredefinedPresets = {
     safe: safePreset,
     ampSafe: ampSafePreset,
     max: maxPreset
@@ -16,10 +16,9 @@ const presets: HtmlnanoPredefinedPresets = {
 
 export function loadConfig(
     options?: HtmlnanoOptions,
-    preset?: HtmlnanoPreset,
-    configPath?: string
+    preset?: HtmlnanoPreset
 ): [Partial<HtmlnanoOptions>, HtmlnanoPreset] {
-    const { skipConfigLoading = false, ...rest } = options || {};
+    const { skipConfigLoading = false, configPath, ...rest } = options || {};
     let restConfig: Partial<HtmlnanoOptions> = rest;
 
     if (!skipConfigLoading) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type PostHTMLNodeLike = PostHTML.Node | string;
 
 export interface HtmlnanoOptions {
     skipConfigLoading?: boolean;
+    configPath?: string;
     skipInternalWarnings?: boolean;
     collapseAttributeWhitespace?: boolean;
     collapseBooleanAttributes?: {
@@ -45,12 +46,12 @@ export interface HtmlnanoOptions {
     sortAttributesWithLists?: boolean | 'alphabetical' | 'frequency';
 }
 
-export interface HtmlnanoPreset extends Omit<HtmlnanoOptions, 'skipConfigLoading'> {}
+export interface HtmlnanoPreset extends Omit<HtmlnanoOptions, 'skipConfigLoading' | 'configPath'> { }
 
 export type HtmlnanoPredefinedPreset = 'safe' | 'ampSafe' | 'max';
 export type HtmlnanoPredefinedPresets = Record<HtmlnanoPredefinedPreset, HtmlnanoPreset>;
 
-export type HtmlnanoOptionsConfigFile = Omit<HtmlnanoOptions, 'skipConfigLoading'> & {
+export type HtmlnanoOptionsConfigFile = Omit<HtmlnanoOptions, 'skipConfigLoading' | 'configPath'> & {
     preset?: HtmlnanoPredefinedPreset;
 };
 

--- a/test/htmlnano.ts
+++ b/test/htmlnano.ts
@@ -44,6 +44,10 @@ describe('[htmlnano]', () => {
     it('should not treat skipConfigLoading as a module name', () => {
         return init('<div></div>', '<div></div>', { skipConfigLoading: true });
     });
+
+    it('should not treat configFile as a module name', () => {
+        return init('<div></div>', '<div></div>', { skipConfigLoading: true, configPath: './test/testrc.json' });
+    });
 });
 
 describe('loadConfig()', () => {
@@ -55,25 +59,25 @@ describe('loadConfig()', () => {
     });
 
     it('should not override the run options or preset', () => {
-        expect(loadConfig({ foo: 'bar' }, ampSafePreset, './test/testrc.json')).toEqual([
+        expect(loadConfig({ foo: 'bar', configPath: './test/testrc.json' }, ampSafePreset)).toEqual([
             { foo: 'bar' },
             ampSafePreset
         ]);
     });
 
     it('should load options and preset from RC files', () => {
-        expect(loadConfig(undefined, undefined, './test/testrc.json')).toEqual([
+        expect(loadConfig({ configPath: './test/testrc.json' }, undefined)).toEqual([
             { foo: 'baz' },
             maxPreset
         ]);
     });
 
     it('should not load options and preset from RC files if skipConfigLoading is true', () => {
-        const options = { skipConfigLoading: true };
-        const loaded = loadConfig(options, undefined, './test/testrc.json');
+        const options = { skipConfigLoading: true, configPath: './test/testrc.json' };
+        const loaded = loadConfig(options, undefined);
 
         expect(loaded).toEqual([{}, safePreset]);
-        expect(options).toEqual({ skipConfigLoading: true });
+        expect(options).toEqual({ skipConfigLoading: true, configPath: './test/testrc.json' });
     });
 });
 

--- a/test/usage_cli.ts
+++ b/test/usage_cli.ts
@@ -1,0 +1,85 @@
+import { expect } from 'expect';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('[cli]', () => {
+    const distDir = path.resolve(__dirname, '../dist');
+    const bin = path.resolve(distDir, 'bin.js');
+
+    const inputHtml = ' <div><!-- foo --><i>Hello</i> <i>world!</i></div> \n';
+    const minifiedHtml = '<div><i>Hello</i> <i>world!</i></div>';
+    const minifiedHtmlMax = '<div><i>Hello</i><i>world!</i></div>';
+
+    it('reads from STDIN and prints to STDOUT', () => {
+        const stdout = execFileSync(process.execPath, [bin], {
+            input: inputHtml,
+            encoding: 'utf8'
+        });
+        expect(stdout.trim()).toBe(minifiedHtml);
+    });
+
+    it('--preset max', () => {
+        const stdout = execFileSync(process.execPath, [bin, '--preset', 'max'], {
+            input: inputHtml,
+            encoding: 'utf8'
+        });
+        expect(stdout.trim()).toBe(minifiedHtmlMax);
+    });
+
+    it('--preset invalid', () => {
+        const res = spawnSync(process.execPath, [bin, '-p', 'invalid'], {
+            input: inputHtml,
+            encoding: 'utf8'
+        });
+
+        expect(res.error).toBeUndefined();
+        expect(res.status).toBe(1);
+        expect((res.stdout || '').trim()).toBe('');
+        expect((res.stderr || '').trim()).toBe('Unknown preset: invalid. Available presets: safe, ampSafe, max');
+    });
+
+    it('specify config file', () => {
+        const configFile = path.resolve(distDir, 'cli-config.tmp.json');
+        try {
+            fs.writeFileSync(
+                configFile,
+                JSON.stringify({
+                    collapseWhitespace: 'all'
+                }),
+                'utf8'
+            );
+
+            const stdout = execFileSync(process.execPath, [bin, '-c', configFile], {
+                input: inputHtml,
+                encoding: 'utf8'
+            });
+            expect(stdout.trim()).toBe(minifiedHtmlMax);
+        } finally {
+            if (fs.existsSync(configFile)) fs.unlinkSync(configFile);
+        }
+    });
+
+    it('read from a file and print to a file', () => {
+        const inFile = path.resolve(distDir, 'cli-input.tmp.html');
+        const outFile = path.resolve(distDir, 'cli-output.tmp.html');
+
+        try {
+            fs.writeFileSync(inFile, inputHtml, 'utf8');
+
+            const res = spawnSync(process.execPath, [bin, inFile, '-o', outFile], {
+                encoding: 'utf8'
+            });
+
+            expect(res.error).toBeUndefined();
+            expect(res.status).toBe(0);
+            expect((res.stdout || '').trim()).toBe('');
+
+            const written = fs.readFileSync(outFile, 'utf8').trim();
+            expect(written).toBe(minifiedHtml);
+        } finally {
+            if (fs.existsSync(inFile)) fs.unlinkSync(inFile);
+            if (fs.existsSync(outFile)) fs.unlinkSync(outFile);
+        }
+    });
+});


### PR DESCRIPTION
For now, I made it quite simple: the options can be passed only via the configuration file. 

Later, we might add CLI args for the options.

The help section:
```
# ./dist/bin.js --help
Usage: htmlnano [options] [input]

Minify HTML with htmlnano

Arguments:
  input                  input file (default: "-")

Options:
  -o, --output <file>    output file (default: "-")
  -p, --preset <preset>  preset to use (default: "safe")
  -c, --config <file>    path to config file
  -h, --help             display help for command
```

It relies on #383 bug fix.

Original issue: #3 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a command-line interface to run htmlnano from the terminal, supporting stdin/stdout, file input/output, presets, and external config files with clear errors for invalid presets.
  - Exposed the list of presets for programmatic use.
  - Added support for specifying a custom config file path via options.

- Documentation
  - Added CLI usage instructions and examples.
  - Documented custom configuration file paths.

- Tests
  - Added end-to-end tests covering CLI I/O, presets (valid/invalid), and config-file workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->