### PR TITLE
fix: restore the default export on the CommonJS build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -344,5 +344,8 @@ export function htmlMinimizerWebpackPluginMinify(
 export default htmlnano;
 
 if (typeof module !== 'undefined') {
-    module.exports = htmlnano;
+    // exporting the callable replaces the exports object, dropping the bundler's
+    // exports.default, so re-attach it for interop consumers and for internal
+    // modules that import htmlnano itself
+    module.exports = Object.assign(htmlnano, { default: htmlnano });
 }

--- a/test/htmlnano_compat.ts
+++ b/test/htmlnano_compat.ts
@@ -17,4 +17,34 @@ describe('[commonjs usage]', () => {
             expect(result.html).toBe(minifiedHtml);
         });
     });
+
+    it('default export', () => {
+        // assigning module.exports drops the bundler's exports.default, which breaks interop
+        // consumers and the modules that reach back into htmlnano itself
+        expect((htmlnano as unknown as { default: unknown }).default).toBe(htmlnano);
+    });
+
+    it('minifyHtmlTemplate module', () => {
+        return htmlnano.process('<template> <div>Hello</div> </template>').then((result) => {
+            expect(result.html).toBe('<template><div>Hello</div></template>');
+        });
+    });
+
+    it('minifyHtmlTemplate module - raw text template', () => {
+        return htmlnano.process('<script type="text/html"> <div>  <b>Hi</b>  </div> </script>', {
+            collapseWhitespace: 'conservative',
+            minifyHtmlTemplate: true
+        }).then((result) => {
+            expect(result.html).toBe('<script type="text/html"><div> <b>Hi</b> </div></script>');
+        });
+    });
+
+    it('minifyConditionalComments module', () => {
+        return htmlnano.process('<!--[if IE 6]><p>You are   using IE 6</p><![endif]-->', {
+            collapseWhitespace: 'conservative',
+            minifyConditionalComments: true
+        }).then((result) => {
+            expect(result.html).toBe('<!--[if IE 6]><p>You are using IE 6</p><![endif]-->');
+        });
+    });
 });


### PR DESCRIPTION
`src/index.ts` ends with `module.exports = htmlnano`, which replaces the exports object so the bundler's `exports.default` never lands on it. That was harmless until 3.4.1: the CJS build used to keep a real dynamic `import()`, and Node's interop put the `default` layer back for the modules that load htmlnano through its own entrypoint. bunchee v7 downlevels that to a `require()`, which gets no wrapper, so `default` is now undefined and `minifyHtmlTemplate` (on in `safe`) and `minifyConditionalComments` (on in `max`) throw on any input they match.

Re-attaching `default` to the callable fixes both without changing what `require('htmlnano')` returns.

Also adds four tests to `test/htmlnano_compat.ts`, the only file that loads the CJS build. Everything else imports `dist/index.mjs`, which is why this got through.

Fixes #458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the CommonJS default export behavior so the default export references the main HTML minification function.
  * Improved compatibility for template and conditional-comment minification when using CommonJS imports.

* **Tests**
  * Added coverage for default exports and CommonJS template-minification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->